### PR TITLE
Add history data api endpoint

### DIFF
--- a/backend/app/routes/markets.js
+++ b/backend/app/routes/markets.js
@@ -116,4 +116,15 @@ router.get("/promo", async (req, res) => {
   }
 });
 
+router.get("/history/:symbol/:period", async (req, res) => {
+  try {
+    const { symbol, period } = req.params;
+    const hData = await iex.history(symbol, { period });
+
+    res.status(200).json(hData);
+  } catch (err) {
+    res.status(500).json({ message: `Server Error: ${err}` });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
This PR creates an endpoint to fetch historical data for a specific company, to use for the data viz bit on the graph.

Request: `GET - api/markets/history/:symbol/:period`

Symbol = _string_ stocker ticker of company (eg: `AAPL`)
Priod = _string_ can be one of the following: "1d", "1m", "3m", "6m", "ytd", "1y", "2y", "5y", "dynamic", "max", "date"

- "1m" seems like a manageable amount of data for initial development.

I'd also like to cache this data at some point. Will likely end up using redis.